### PR TITLE
Update to Hive-2.1.1 which forces the use of Derby instead of HsqlDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-# 1.0.2
+## Unreleased
+### Changed 
+* Upgrade to Hive-2.1.1, required a switch from HsqlDB to Derby (Hive no longer seems to support HsqlDB)
+
+## [1.0.2]
+### Changed 
 * Upgrade parent POM to 1.1.1
 
-# 1.0.1
+## [1.0.1]
+### Addded 
 * Addition of `HiveServer2JUnitRule` rule to test against Hive Metastore using the JDBC API.
 
-# 1.0.0
+## [1.0.0]
+### Added
 * First release: `HiveMetaStoreJUnitRule` and `ThriftHiveMetaStoreJUnitRule` rules to test a Hive Metastore connecting directly to the database and the Thrift API respectively.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BeeJU
-![Hive Bee JUnit.](logo.png "Project logo of a bijou bee.")
+![Hive Bee JUnit.](logo.png "Project logo of a beeju bee.")
                                
 # Start using
 You can obtain BeeJU from Maven Central : 
@@ -8,7 +8,7 @@ You can obtain BeeJU from Maven Central :
 
 # Overview
 BeeJU provides [JUnit rules](http://junit.org/junit4/javadoc/4.12/org/junit/Rule.html) that can be used to write test code that tests [Hive](https://hive.apache.org/). A JUnit rule is a means to provide resources in a test and automatically tear them down when the life cycle of a test ends.
-This project is currently built with and tested against Hive 1.2.1 but is most likely compatible with older and newer versions of Hive. The available JUnit rules are explained in more detail below.  
+This project is currently built with and tested against Hive 2.1.1 (and Hive 1.2.1) but is most likely compatible with older and newer versions of Hive. The available JUnit rules are explained in more detail below.  
 
 # Usage
 The BeeJU JUnit rules provide a way to run tests that have an underlying requirement to use the Hive Metastore API but don't have the ability to mock the [Hive Metastore Client](https://hive.apache.org/javadocs/r1.2.1/api/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.html). The rules spin up and tear down an in-memory Metastore which may add few seconds to the test life cycle so if you require tests to run in the sub-second range this is not for you.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <hadoop.version>2.7.1</hadoop.version>
-    <hive.version>1.2.1</hive.version>
+    <hive.version>2.1.1</hive.version>
     <junit.version>4.11</junit.version>
     <hsqldb.version>2.3.1</hsqldb.version>
   </properties>
@@ -56,20 +56,6 @@
       <artifactId>hive-metastore</artifactId>
       <version>${hive.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.derby</groupId>
-          <artifactId>derby</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.derby</groupId>
-          <artifactId>derbyclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.derby</groupId>
-          <artifactId>derbynet</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -82,11 +68,6 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${hive.version}</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <version>${hsqldb.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>beeju</artifactId>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
 
   <scm>


### PR DESCRIPTION
fixes #4 