### PR TITLE
Change scm section from SSH to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <version>1.3.2-SNAPSHOT</version>
 
   <scm>
-    <connection>scm:git:git@github.com:HotelsDotCom/beeju.git</connection>
-    <developerConnection>scm:git:git@github.com:HotelsDotCom/beeju.git</developerConnection>
+    <connection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/HotelsDotCom/beeju.git</connection>
+    <developerConnection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/HotelsDotCom/beeju.git</developerConnection>
     <url>https://github.com/HotelsDotCom/beeju</url>
     <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
Going forward our new Jenkins deployment agents will only support HTTPS access to Github.com, not SSH so we need this change. I can only really test it by doing a release build so need to get this merged.