### PR TITLE
Public constructors for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This extension creates an in-memory Hive database, a Thrift Hive Metastore servi
 
 Example usage: Class under test drops a table via Hive JDBC.
 
-    @Rule
+    @RegisterExtension
     public HiveServer2JUnitExtension hive = new HiveServer2JUnitExtension("foo_db");
     
     @Test

--- a/src/main/java/com/hotels/beeju/extensions/HiveMetaStoreJUnitExtension.java
+++ b/src/main/java/com/hotels/beeju/extensions/HiveMetaStoreJUnitExtension.java
@@ -35,7 +35,7 @@ public class HiveMetaStoreJUnitExtension extends BeejuJUnitExtension {
   /**
    * Create a Hive Metastore with a pre-created database "test_database".
    */
-  HiveMetaStoreJUnitExtension() {
+  public HiveMetaStoreJUnitExtension() {
     this("test_database");
   }
 
@@ -44,7 +44,7 @@ public class HiveMetaStoreJUnitExtension extends BeejuJUnitExtension {
    *
    * @param databaseName Database name.
    */
-  HiveMetaStoreJUnitExtension(String databaseName) {
+  public HiveMetaStoreJUnitExtension(String databaseName) {
     this(databaseName, null);
   }
 
@@ -54,7 +54,7 @@ public class HiveMetaStoreJUnitExtension extends BeejuJUnitExtension {
    * @param databaseName Database name.
    * @param configuration Hive configuration properties.
    */
-  HiveMetaStoreJUnitExtension(String databaseName, Map<String, String> configuration) {
+  public HiveMetaStoreJUnitExtension(String databaseName, Map<String, String> configuration) {
     super(databaseName, configuration);
     hiveMetaStoreCore = new HiveMetaStoreCore(core);
   }

--- a/src/main/java/com/hotels/beeju/extensions/HiveServer2JUnitExtension.java
+++ b/src/main/java/com/hotels/beeju/extensions/HiveServer2JUnitExtension.java
@@ -29,7 +29,7 @@ public class HiveServer2JUnitExtension extends BeejuJUnitExtension {
   /**
    * Create a HiveServer2 service with a pre-created database "test_database".
    */
-  HiveServer2JUnitExtension() {
+  public HiveServer2JUnitExtension() {
     this("test_database");
   }
 
@@ -38,7 +38,7 @@ public class HiveServer2JUnitExtension extends BeejuJUnitExtension {
    *
    * @param databaseName Database name.
    */
-  HiveServer2JUnitExtension(String databaseName) {
+  public HiveServer2JUnitExtension(String databaseName) {
     this(databaseName, null);
   }
 
@@ -48,7 +48,7 @@ public class HiveServer2JUnitExtension extends BeejuJUnitExtension {
    * @param databaseName Database name.
    * @param configuration Hive configuration properties.
    */
-  HiveServer2JUnitExtension(String databaseName, Map<String, String> configuration) {
+  public HiveServer2JUnitExtension(String databaseName, Map<String, String> configuration) {
     super(databaseName, configuration);
     hiveServer2Core = new HiveServer2Core(core);
   }


### PR DESCRIPTION
The constructors for HiveMetaStoreJUnitExtension and HiveServer2JUnitExtension are package-private, so they cannot be used outside the com.hotels.beeju.extensions package. This PR fixes that problem.