### PR TITLE
Update JUnit5 and parent pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - Depend on `junit-jupiter` (was `junit-jupiter-api`).
 - `hotels-oss-parent` version updated to `4.2.0` (was `4.1.0`).
 
-
 ## [3.0.1] - 2019-09-27
 ### Changed
 - `HiveMetaStoreJUnitExtension` and `HiveServer2JUnitExtension` constructors made public to allow access to classes outside of the extensions package. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.1.0] - TBD
+### Changed
+- JUnit version updated to `5.5.2` (was 5.5.1).
+- Depend on `junit-jupiter` (was `junit-jupiter-api`).
+- `hotels-oss-parent` version updated to `4.2.0` (was `4.1.0`).
+
+
 ## [3.0.1] - 2019-09-27
 ### Changed
 - `HiveMetaStoreJUnitExtension` and `HiveServer2JUnitExtension` constructors made public to allow access to classes outside of the extensions package. 

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,16 @@
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
   </parent>
 
   <artifactId>beeju</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/HotelsDotCom/beeju.git</connection>
@@ -22,7 +23,7 @@
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.4</hive.version>
     <jdk.version>1.8</jdk.version>
-    <junit.jupiter.version>5.5.1</junit.jupiter.version>
+    <junit.jupiter.version>5.5.2</junit.jupiter.version>
   </properties>
 
   <dependencies>
@@ -101,7 +102,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.jupiter.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
The change in JUnit dependency is needed in order to get the tests running in Eclipse and also seems to be the recommended way to use JUnit5 (see https://github.com/junit-team/junit5-samples/blob/r5.5.2/junit5-jupiter-starter-maven/pom.xml).