### PR TITLE
Allow setting hive conf which doesn't have a hivevar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Depend on `junit-jupiter` (was `junit-jupiter-api`).
 - `hotels-oss-parent` version updated to `4.2.0` (was `4.1.0`).
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows BeeJU to be used on JDK>=9.
+- Add support for setting hive conf using arbitrary string as conf key 
 
 ## [3.0.1] - 2019-09-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 - Depend on `junit-jupiter` (was `junit-jupiter-api`).
 - `hotels-oss-parent` version updated to `4.2.0` (was `4.1.0`).
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows BeeJU to be used on JDK>=9.
-- Add support for setting hive conf using arbitrary string as conf key 
+
+### Added
+- Support for setting Hive conf using arbitrary string as conf key.
 
 ## [3.0.1] - 2019-09-27
 ### Changed

--- a/src/main/java/com/hotels/beeju/core/BeejuCore.java
+++ b/src/main/java/com/hotels/beeju/core/BeejuCore.java
@@ -101,6 +101,10 @@ public class BeejuCore {
     conf.setVar(variable, value);
   }
 
+  void setHiveConf(String variable, String value) {
+    conf.set(variable, value);
+  }
+
   void setHiveIntVar(HiveConf.ConfVars variable, int value) {
     conf.setIntVar(variable, value);
   }

--- a/src/test/java/com/hotels/beeju/core/BeejuCoreTest.java
+++ b/src/test/java/com/hotels/beeju/core/BeejuCoreTest.java
@@ -78,6 +78,12 @@ public class BeejuCoreTest {
   }
 
   @Test
+  public void setHiveConf() {
+    defaultCore.setHiveConf("my.custom.key", "test");
+    assertThat(defaultCore.conf().get("my.custom.key"), is("test"));
+  }
+
+  @Test
   public void setHiveIntVar() {
     defaultCore.setHiveIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_PORT, 00000);
     assertThat(defaultCore.conf().getIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_PORT), is(00000));


### PR DESCRIPTION
We use this library to test metastore audit logger plugin we use. The plugin uses configurations like http url of ingestion service etc.  As of now there is no ability to set `HiveConf.ConfVars` in `BeejuCore`.  This adds the ability to set custom configuration keys by string in hive conf object. 