### PR TITLE
Remove xerces test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,13 +105,6 @@
       <version>${junit.jupiter.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- below removes "Failed to set setXIncludeAware(true)" warnings in log when running cobertura -->
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>2.11.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
We no longer use Cobertura so don't need to overwrite the version of Xerces. Removing it means we don't need to keep it up to date (I just received a dependabot alert about it).