### PR TITLE
Support for setting Thrift Hive Metastore port in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.2.0] - TBD
+### Added
+- Support for setting Thrift Hive Metastore port in tests.
+- A `ThriftHiveMetaStoreApp` which can be used to run the the Thrift Hive Metastore service locally.
+
 ## [3.1.0] - 2020-05-13
 ### Changed
 - JUnit version updated to `5.5.2` (was 5.5.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Support for setting Thrift Hive Metastore port in tests.
 - A `ThriftHiveMetaStoreApp` which can be used to run the the Thrift Hive Metastore service locally.
 
+### Changed
+- Changed visibility of `createDatabase()` method in `BeejuJUnitRule` from default to public (for external usage). 
+
 ## [3.1.0] - 2020-05-13
 ### Changed
 - JUnit version updated to `5.5.2` (was 5.5.1).

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>beeju</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/HotelsDotCom/beeju.git</connection>

--- a/src/main/java/com/hotels/beeju/BeejuJUnitRule.java
+++ b/src/main/java/com/hotels/beeju/BeejuJUnitRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ abstract class BeejuJUnitRule extends ExternalResource {
    * @param databaseName Database name.
    * @throws TException If an error occurs creating the database.
    */
-  void createDatabase(String databaseName) throws TException {
+  public void createDatabase(String databaseName) throws TException {
     core.createDatabase(databaseName);
   }
 }

--- a/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreApp.java
+++ b/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreApp.java
@@ -23,8 +23,7 @@ public class ThriftHiveMetaStoreApp {
     ThriftHiveMetaStoreJUnitRule rule = new ThriftHiveMetaStoreJUnitRule();
     rule.setThriftPort(22334);
     rule.before();
-    System.out.println("Beeju Thrift Hive Metastore listening on: " + rule.getThriftConnectionUri());
-    // TODO: also test BeeJU still works with these changes in a local downstream project
+    System.out.println("BeeJU Thrift Hive Metastore listening on: " + rule.getThriftConnectionUri());
     CountDownLatch latch = new CountDownLatch(1);
     latch.await();
   }

--- a/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreApp.java
+++ b/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreApp.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.beeju;
+
+import java.util.concurrent.CountDownLatch;
+
+public class ThriftHiveMetaStoreApp {
+
+  public static void main(String[] args) throws Throwable {
+    ThriftHiveMetaStoreJUnitRule rule = new ThriftHiveMetaStoreJUnitRule();
+    rule.setThriftPort(22334);
+    rule.before();
+    System.out.println("Beeju Thrift Hive Metastore listening on: " + rule.getThriftConnectionUri());
+    // TODO: also test BeeJU still works with these changes in a local downstream project
+    CountDownLatch latch = new CountDownLatch(1);
+    latch.await();
+  }
+
+}

--- a/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreJUnitRule.java
+++ b/src/main/java/com/hotels/beeju/ThriftHiveMetaStoreJUnitRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,13 @@ public class ThriftHiveMetaStoreJUnitRule extends HiveMetaStoreJUnitRule {
    */
   public int getThriftPort() {
     return thriftHiveMetaStoreCore.getThriftPort();
+  }
+  
+  /**
+   * @param thriftPort The Port to use for the Thrift Hive metastore, if not set then a port number will automatically be allocated.
+   */
+  public void setThriftPort(int thriftPort) {
+    thriftHiveMetaStoreCore.setThriftPort(thriftPort);
   }
 
 }

--- a/src/main/java/com/hotels/beeju/core/BeejuCore.java
+++ b/src/main/java/com/hotels/beeju/core/BeejuCore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/beeju/extensions/ThriftHiveMetaStoreJUnitExtension.java
+++ b/src/main/java/com/hotels/beeju/extensions/ThriftHiveMetaStoreJUnitExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,5 +83,12 @@ public class ThriftHiveMetaStoreJUnitExtension extends HiveMetaStoreJUnitExtensi
    */
   public int getThriftPort() {
     return thriftHiveMetaStoreCore.getThriftPort();
+  }
+  
+  /**
+   * @param thriftPort The Port to use for the Thrift Hive metastore, if not set then a port number will automatically be allocated.
+   */
+  public void setThriftPort(int thriftPort) {
+    thriftHiveMetaStoreCore.setThriftPort(thriftPort);
   }
 }

--- a/src/test/java/com/hotels/beeju/ThriftHiveMetaStoreJUnitRuleTest.java
+++ b/src/test/java/com/hotels/beeju/ThriftHiveMetaStoreJUnitRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,13 @@ public class ThriftHiveMetaStoreJUnitRuleTest {
   @Test(expected = InvalidObjectException.class)
   public void createDatabaseInvalidName() throws TException {
     hiveDefaultName.createDatabase("");
+  }
+
+  @Test
+  public void thriftPort() {
+    int thriftPort = 3333;
+    hiveDefaultName.setThriftPort(thriftPort);
+    assertThat(hiveDefaultName.getThriftPort(), is(thriftPort));
   }
 
   @AfterClass

--- a/src/test/java/com/hotels/beeju/core/BeejuCoreTest.java
+++ b/src/test/java/com/hotels/beeju/core/BeejuCoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/beeju/core/ThriftHiveMetaStoreCoreTest.java
+++ b/src/test/java/com/hotels/beeju/core/ThriftHiveMetaStoreCoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,20 @@ public class ThriftHiveMetaStoreCoreTest {
     List<String> databases = client.getAllDatabases();
     assertThat(databases.size(), is(1));
     assertThat(databases.get(0), is("default"));
+  }
+
+  @Test
+  public void validThriftPort() throws Exception {
+    int thriftPort = 3333;
+    thriftHiveMetaStoreCore.setThriftPort(3333);
+    assertThat(thriftHiveMetaStoreCore.getThriftPort(), is(thriftPort));
+    thriftHiveMetaStoreCore.initialise();
+    assertThat(thriftHiveMetaStoreCore.getThriftPort(), is(thriftPort));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidThriftPort() {
+    thriftHiveMetaStoreCore.setThriftPort(-1);
   }
 
 }

--- a/src/test/java/com/hotels/beeju/extensions/ThriftHiveMetaStoreJUnitExtensionTest.java
+++ b/src/test/java/com/hotels/beeju/extensions/ThriftHiveMetaStoreJUnitExtensionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015-2019 Expedia, Inc.
+ * Copyright (C) 2015-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,5 +94,12 @@ public class ThriftHiveMetaStoreJUnitExtensionTest{
   @Test
   public void createDatabaseInvalidName() {
     assertThrows(InvalidObjectException.class, () -> hiveDefaultName.createDatabase(""));
+  }
+  
+  @Test
+  public void thriftPort() {
+    int thriftPort = 3333;
+    hiveDefaultName.setThriftPort(thriftPort);
+    assertThat(hiveDefaultName.getThriftPort(), is(thriftPort));
   }
 }


### PR DESCRIPTION
While creating some integration tests for Iceberg's usage of Hive I found it would be useful to have a local Hive metastore running as a separate application. One could do this using the HMS itself but since BeeJU already has this all set up nicely it's really easy to do this by running a BeeJU "app" from inside an IDE. This PR adds that as well as the ability to set the Thrift port in use for situations like this where one wants to guarantee it instead of just choosing any available one.

In testing this downstream in WaggleDance I found it requires the visibility of `createDatabase()` in `BeejuJUnitRule` to be opened up again so I've done this here too.